### PR TITLE
Add chessboard patterns and textures to material system

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>12: Multiple Workers</title>
+  <title>13: Patterns</title>
   <link type="text/css" rel="stylesheet" href="style.css" />
 </head>
 

--- a/modules/patterns/chessboard.js
+++ b/modules/patterns/chessboard.js
@@ -15,17 +15,13 @@ export class Chessboard extends Material {
     }
 }
 
-export class Chessblock extends Material {
-    constructor(color1, color2, size = 1) 
-    {
-        super();
-        this.color1 = color1;
-        this.color2 = color2;
-        this.size = size;
+export class Chessblock extends Chessboard {
+    
+    constructor(color1, color2, size = 1) {
+        super(color1, color2, size);
     }
 
-    getColorAt = point => 
-    {
+    getColorAt = point => {
         let rank = Math.floor(point.x/this.size) % 2;
         let file = Math.floor(point.z/this.size) % 2;
         let alti = Math.floor(point.y/this.size) % 2;

--- a/modules/patterns/chessboard.js
+++ b/modules/patterns/chessboard.js
@@ -4,7 +4,7 @@ export class Chessboard extends Material {
     constructor(color1, color2, size = 1) {
         super();
         this.color1 = color1;
-        this.color2 = color1;
+        this.color2 = color2;
         this.size = size;
     }
     getColorAt = point => {

--- a/modules/patterns/chessboard.js
+++ b/modules/patterns/chessboard.js
@@ -1,0 +1,35 @@
+import { Material } from '../material.js';
+
+export class Chessboard extends Material {
+    constructor(color1, color2, size = 1) {
+        super();
+        this.color1 = color1;
+        this.color2 = color1;
+        this.size = size;
+    }
+    getColorAt = point => {
+        let rank = Math.floor(point.x/this.size);
+        let file = Math.floor(point.z/this.size);
+        let light = ((rank ^ file) & 1) == 1;
+        return (light ? this.color1 : this.color2);
+    }
+}
+
+export class Chessblock extends Material {
+    constructor(color1, color2, size = 1) 
+    {
+        super();
+        this.color1 = color1;
+        this.color2 = color2;
+        this.size = size;
+    }
+
+    getColorAt = point => 
+    {
+        let rank = Math.floor(point.x/this.size) % 2;
+        let file = Math.floor(point.z/this.size) % 2;
+        let alti = Math.floor(point.y/this.size) % 2;
+        let light = ((rank ^ file ^ alti) & 1) == 1;
+        return (light ? this.color1 : this.color2);
+    }
+}

--- a/modules/patterns/patterns.js
+++ b/modules/patterns/patterns.js
@@ -1,0 +1,5 @@
+import { Chessboard, Chessblock } from './chessboard.js';
+import { Tiles } from './tiles.js';
+import { Stripes } from './stripes.js';
+
+export { Chessboard, Chessblock, Tiles, Stripes };

--- a/modules/patterns/stripes.js
+++ b/modules/patterns/stripes.js
@@ -1,0 +1,10 @@
+import { Material } from '../material.js';
+
+export class Stripes extends Material {
+    constructor(color1, color2) {
+        super();
+        this.color1 = color1;
+        this.color2 = color2;
+    }
+    getColorAt = point => Math.round(point.x) % 2 == 0 ? this.color1 : this.color2;
+}

--- a/modules/patterns/tiles.js
+++ b/modules/patterns/tiles.js
@@ -1,0 +1,21 @@
+import { Material } from '../material.js';
+
+export class Tiles extends Material {
+    constructor(size, spacing, color1, color2) {
+        super();
+        this.size = size;
+        this.spacing = spacing;
+        this.color1 = color1;
+        this.color2 = color2;
+    }
+    getColorAt = point => {
+        let xs = this.size.x + this.spacing;
+        let ys = this.size.y + this.spacing;
+        let zs = this.size.z + this.spacing;
+        let xx = (((point.x - xs / 2) % xs) + xs) % xs;
+        let yy = (((point.y - ys / 2) % ys) + ys) % ys;
+        let zz = (((point.z - zs / 2) % zs) + zs) % zs;
+        if (xx < this.spacing || yy < this.spacing || zz < this.spacing) return this.color2;
+        return this.color1;
+    }
+}

--- a/scenes/examples.js
+++ b/scenes/examples.js
@@ -5,6 +5,7 @@ import { Box } from '../modules/shapes/box.js';
 import { Light } from '../modules/light.js';
 import { Appearance } from '../modules/appearance.js';
 import { Finish } from '../modules/finish.js'; 
+import * as Patterns from '../modules/patterns/patterns.js';
 
 export function EmptySky() {
     let camera = new Camera(new Vector(-4, 1, -5), new Vector(0, 1, 0));
@@ -26,13 +27,13 @@ export function ColoredSpheres() {
     return new Scene(camera, background, shapes, lights);
 }
 
-export function AssortedShapes(reflection = 0.5) {    
+export function AssortedShapes(reflection = 0.5, appearance = new Appearance(Color.White)) {    
     let camera = new Camera(new Vector(-5, 5, -12), new Vector(0, 3, 0), 3.2, 1.8);
     let background = new Color(0, 0, 0);
     let lights = [new Light(new Vector(-30, 25, -12), Color.White)];
     let finish = new Finish({reflection: reflection});
     let shapes = [
-        new Plane(Vector.Y, 0, new Appearance(Color.White)),
+        new Plane(Vector.Y, 0, appearance),
         new Box(new Vector(-2, 0, -2), new Vector(2, 4, 2), new Appearance(Color.Red, finish)),
         new Sphere(new Vector(6, 2, 0), 2, new Appearance(Color.Magenta, finish)),
         new Sphere(new Vector(6, 1, -4), 1, new Appearance(Color.Yellow, finish)),
@@ -101,6 +102,76 @@ export function ColoredLights() {
         new Sphere(new Vector(SPACING * +0, 1, -SPACING), RADIUS, new Appearance(color, new Finish({ ambient: 0.4, diffuse: 0.3, shiny: 1.0 }))),
         new Sphere(new Vector(SPACING * +1, 1, -SPACING), RADIUS, new Appearance(color, new Finish({ ambient: 0.2, diffuse: 0.6, shiny: 1.0 }))),
         new Sphere(new Vector(SPACING * +2, 1, -SPACING), RADIUS, new Appearance(color, new Finish({ ambient: 0.0, diffuse: 1.0, shiny: 1.0 }))),
+    ];
+    return new Scene(camera, background, shapes, lights);
+}
+
+export function ShapesOnTiledFloor() {
+  let tiles = new Appearance(
+      new Tiles(new Vector(1, 1, 1), 0.05, Color.Black, Color.White),
+      new Finish({ ambient: 0.2, diffuse: 0.7, reflection: 0.5 })
+  );
+  return AssortedShapes(0.5, tiles);
+}
+
+export function ShapesOnStripedFloor() {
+  let stripes = new Appearance(
+      new Stripes(Color.Black, Color.White),
+      new Finish({ ambient: 0, diffuse: 0.7, reflection: 0.2 })
+  );
+  return AssortedShapes(0.5, stripes);
+}
+
+export function Chessball() {
+    let chessboard = new Appearance(
+        new Patterns.Chessboard(
+            Color.Black, Color.White, 0.5),
+        new Finish({shiny: 0.8}) 
+    );
+    let chessblock = new Appearance(
+        new Patterns.Chessblock(Color.Black, Color.White, 0.5),
+        new Finish({shiny: 0.8}) 
+    );
+    let camera = new Camera(new Vector(0, 4, -10), new Vector(0, 0, 0), 1.6, 0.9);
+    let background = new Color(0, 0, 0);
+    let lights = [
+        new Light(new Vector(0, 20, -20), Color.White),
+        // new Light(new Vector(0, 20, -20), new Color(120, 180, 120)),
+        // new Light(new Vector(17, 20, 10), new Color(20, 20, 180)),
+    ];
+    let shapes = [
+        // new Box(new Vector(-4,-0.2,-4), new Vector(4,0,4), chessboard)
+        new Sphere(Vector.X.scale(-2), 1.5, chessboard),
+        new Sphere(Vector.X.scale(2), 1.5, chessblock),
+    ];
+    return new Scene(camera, background, shapes, lights);
+}
+
+
+export function ShapesOnChessboard() {
+    let chessboard = new Appearance(
+        new Patterns.Chessboard(Color.Black, Color.White, 2),
+        new Finish({ ambient: 0.2, diffuse: 0.7, reflection: 0.4 })
+    );
+    let camera = new Camera(new Vector(-3, 10, -28), new Vector(4, 1, 4), 16/8, 9/8);
+    let background = new Color(0, 0, 0);
+    let lights = [new Light(new Vector(-30, 25, -12), Color.White)];
+    let reflection = 0.5;
+    let finish = new Finish({reflection: reflection, shiny: 0.8});
+    let shapes = [
+        new Plane(Vector.Y, -0.3, new Appearance(new Color(100,120,150))),
+        new Box(new Vector(-8,-0.3,-8), new Vector(8,0,8), chessboard),
+        new Box(new Vector(-8.5,-0.3,-8.5), new Vector(8.5,-0.001,8.5), 
+            new Appearance(Color.Grey, new Finish({ambient: 0.4, diffuse: 0.7}))
+        ),
+        
+        new Box(new Vector(-1.8, 0, -4.8), new Vector(1.8, 4, -1.2), new Appearance(Color.Red, finish)),
+        new Sphere(new Vector(6, 2, -2), 2, new Appearance(Color.Magenta, finish)),
+        new Sphere(new Vector(6, 1, -6), 1, new Appearance(Color.Yellow, finish)),
+        new Sphere(new Vector(-2, 2, 1), 2, new Appearance(Color.Green, new Finish({shiny: 0.8, reflection: reflection}))),
+        new Sphere(new Vector(-4, 3, 6), 3, new Appearance(Color.Blue, new Finish({shiny: 0.5, reflection: reflection}))),
+        new Sphere(new Vector(-3.4, 1, -3), 1, new Appearance(Color.Cyan, new Finish({ shiny: 0.8, reflection: reflection }))),
+        new Sphere(new Vector(1.2, 0.5, -6.2), 0.5, new Appearance(Color.Black, new Finish({ shiny: 0.8, reflection: reflection }))),
     ];
     return new Scene(camera, background, shapes, lights);
 }

--- a/worker.js
+++ b/worker.js
@@ -32,8 +32,8 @@ self.addEventListener('message', function (message) {
     switch (data.command) {
         case 'render':
             let renderer = new Renderer(data.width, data.height);
-            let scene = ExampleScenes.AssortedShapes();
-            let callback = makeCallback(data.block, 40);
+            let scene = ExampleScenes.ShapesOnChessboard(); // ShapesOnTiledFloor();
+            let callback = makeCallback(data.block, 20);
             renderer.render(scene, callback, data.block);
             self.close();
             self.postMessage({ command: 'finished' });


### PR DESCRIPTION
This PR extends the material system in JSRay so that shapes can be made from textures as well as just solid colours. It includes two example textures which are different kinds of chessboard pattern.